### PR TITLE
Add default paths for test results and reports. [semver:patch]

### DIFF
--- a/src/commands/collect_test_results.yml
+++ b/src/commands/collect_test_results.yml
@@ -6,9 +6,11 @@ parameters:
   test_results_path:
     description: Results to be published
     type: string
+    default: build/test-results/
   reports_path:
     description: Artifacts to be published
     type: string
+    default: build/reports/
 steps:
   - when:
       condition: <<parameters.test_results_path>>

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -12,9 +12,11 @@ parameters:
   test_results_path:
     description: Results to be published
     type: string
+    default: build/test-results/
   reports_path:
     description: Artifacts to be published
     type: string
+    default: build/reports/
   app_src_directory:
     description: Useful when the source of your maven project is nott in the root directory of your git repo. Supply the name of the directory or relative path of the directory containing your source code.
     type: string


### PR DESCRIPTION
Right now [the example](https://github.com/CircleCI-Public/gradle-orb/blob/master/src/examples/build_and_test.yml) configs are invalid since both reports_path and test_results_path are required fields. These values should be good defaults for gradle projects that haven't explicitly changed the paths.