### PR TITLE
Propagate parameters to with_cache correctly

### DIFF
--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -24,10 +24,11 @@ parameters:
 steps:
   - checkout
   - with_cache:
+      cache_key: << parameters.cache_key >>
+      cache_checksum_file: << parameters.cache_checksum_file >>
       steps:
         - run:
             working_directory: << parameters.app_src_directory >>
             name: Run Task
             command: ./gradlew << parameters.command >>
-            cache_key: << parameters.cache_key >>
-            cache_checksum_file: << parameters.cache_checksum_file >>
+

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -32,13 +32,13 @@ parameters:
 steps:
   - checkout
   - with_cache:
+      cache_key: << parameters.cache_key >>
+      cache_checksum_file: << parameters.cache_checksum_file >>
       steps:
         - run:
             name: Run Tests
             working_directory: << parameters.app_src_directory >>
             command: ./gradlew << parameters.test_command >>
-            cache_key: << parameters.cache_key >>
-            cache_checksum_file: << parameters.cache_checksum_file >>
   - collect_test_results:
       test_results_path: <<parameters.test_results_path>>
       reports_path: <<parameters.reports_path>>


### PR DESCRIPTION
For some reason the linter did not catch this. See `with_cache` in the [maven orb](https://circleci.com/developer/orbs/orb/circleci/maven) for reference.

See #11