### PR TITLE
Feat!: Split Wrapper and Deps Caches

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -32,6 +32,7 @@ workflows:
       - gradle/test:
           app_src_directory: sample_app
           reports_path: sample_app/build/reports/
+          cache_key: 'v2'
           test_results_path: sample_app/build/test-results/
           filters: *filters
       - orb-tools/pack:

--- a/src/commands/with_cache.yml
+++ b/src/commands/with_cache.yml
@@ -14,21 +14,37 @@ parameters:
     description: Add a custom suffix to your cache key in the event you need to work with multiple maven caches.
     type: string
     default: "v1"
-  cache_checksum_file:
+  deps_checksum_file:
     description: File to use to generate the cache checksum, defaults to build.gradle.  For example if using Gradle Kotlin DSL then set to build.gradle.kts instead.
     type: string
     default: "build.gradle"
+  wrapper_checksum_file:
+    description: File to use to generate the cache checksum, defaults to build.gradle.  For example if using Gradle Kotlin DSL then set to build.gradle.kts instead.
+    type: string
+    default: "gradlew"
 steps:
   - run:
-      name: Generate Cache Checksum
+      name: Generate Dependencies Checksum
       command: << include(scripts/checksum_files.sh) >>
       environment:
         PARAM_CHECKSUM_FILES: << parameters.cache_checksum_file>>
+        CHECKSUM_SEED_LOCATION: "/tmp/gradle_dep_cache_seed"
+  - run:
+      name: Generate Wrapper Checksum
+      command: << include(scripts/checksum_files.sh) >>
+      environment:
+        PARAM_CHECKSUM_FILES: << parameters.cache_checksum_file>>
+        CHECKSUM_SEED_LOCATION: "/tmp/gradle_wrapper_cache_seed"
   - restore_cache:
-      key: gradle-<< parameters.cache_key>>-{{ checksum "/tmp/gradle_cache_seed" }}-{{ checksum ".circleci/config.yml" }}
+      key: gradle-<< parameters.cache_key>>-{{ checksum "/tmp/gradle_dep_cache_seed" }}
+  - restore_cache:
+      key: gradle-<< parameters.cache_key>>-{{ checksum "/tmp/gradle_wrapper_cache_seed" }}
   - steps: << parameters.steps >>
   - save_cache:
       paths:
         - ~/.gradle/caches
+      key: gradle-<< parameters.cache_key>>-{{ checksum "/tmp/gradle_dep_cache_seed" }}
+  - save_cache:
+      paths:
         - ~/.gradle/wrapper
-      key: gradle-<< parameters.cache_key>>-{{ checksum "/tmp/gradle_cache_seed" }}-{{ checksum ".circleci/config.yml" }}
+      key: gradle-<< parameters.cache_key>>-{{ checksum "/tmp/gradle_wrapper_cache_seed" }}

--- a/src/commands/with_cache.yml
+++ b/src/commands/with_cache.yml
@@ -15,11 +15,11 @@ parameters:
     type: string
     default: "v1"
   deps_checksum_file:
-    description: File to use to generate the cache checksum, defaults to build.gradle.  For example if using Gradle Kotlin DSL then set to build.gradle.kts instead.
+    description: File to use to generate the cache checksum for dependencies. Defaults to build.gradle. For example if using Gradle Kotlin DSL then set to build.gradle.kts instead.
     type: string
     default: "build.gradle"
   wrapper_checksum_file:
-    description: File to use to generate the cache checksum, defaults to build.gradle.  For example if using Gradle Kotlin DSL then set to build.gradle.kts instead.
+    description: File to use to generate the cache checksum for the gradle wrapper. Defaults to gradlew. For example, if testing on Windows, gradlew.bat should be used instead.
     type: string
     default: "gradlew"
 steps:

--- a/src/commands/with_cache.yml
+++ b/src/commands/with_cache.yml
@@ -27,13 +27,13 @@ steps:
       name: Generate Dependencies Checksum
       command: << include(scripts/checksum_files.sh) >>
       environment:
-        PARAM_CHECKSUM_FILES: << parameters.cache_checksum_file>>
+        PARAM_CHECKSUM_FILES: << parameters.deps_checksum_file>>
         CHECKSUM_SEED_LOCATION: "/tmp/gradle_dep_cache_seed"
   - run:
       name: Generate Wrapper Checksum
       command: << include(scripts/checksum_files.sh) >>
       environment:
-        PARAM_CHECKSUM_FILES: << parameters.cache_checksum_file>>
+        PARAM_CHECKSUM_FILES: << parameters.wrapper_checksum_file>>
         CHECKSUM_SEED_LOCATION: "/tmp/gradle_wrapper_cache_seed"
   - restore_cache:
       key: gradle-<< parameters.cache_key>>-{{ checksum "/tmp/gradle_dep_cache_seed" }}

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -17,15 +17,20 @@ parameters:
     description: Add a custom suffix to your cache key in the event you need to work with multiple maven caches.
     type: string
     default: 'v1'
-  cache_checksum_file:
-    description: File to use to generate the cache checksum, defaults to build.gradle.  For example if using Gradle Kotlin DSL then set to build.gradle.kts instead.
+  deps_checksum_file:
+    description: File to use to generate the cache checksum for dependencies. Defaults to build.gradle. For example if using Gradle Kotlin DSL then set to build.gradle.kts instead.
     type: string
     default: 'build.gradle'
+  wrapper_checksum_file:
+    description: File to use to generate the cache checksum for the gradle wrapper. Defaults to gradlew. For example, if testing on Windows, gradlew.bat should be used instead.
+    type: string
+    default: 'gradlew'
 steps:
   - checkout
   - with_cache:
       cache_key: << parameters.cache_key >>
-      cache_checksum_file: << parameters.cache_checksum_file >>
+      deps_checksum_file: << parameters.deps_checksum_file >>
+      wrapper_checksum_file: << parameters.wrapper_checksum_file >>
       steps:
         - run:
             working_directory: << parameters.app_src_directory >>

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -25,15 +25,20 @@ parameters:
     description: Add a custom suffix to your cache key in the event you need to work with multiple maven caches.
     type: string
     default: 'v1'
-  cache_checksum_file:
-    description: File to use to generate the cache checksum, defaults to build.gradle.  For example if using Gradle Kotlin DSL then set to build.gradle.kts instead.
+  deps_checksum_file:
+    description: File to use to generate the cache checksum for dependencies. Defaults to build.gradle. For example if using Gradle Kotlin DSL then set to build.gradle.kts instead.
     type: string
     default: 'build.gradle'
+  wrapper_checksum_file:
+    description: File to use to generate the cache checksum for the gradle wrapper. Defaults to gradlew. For example, if testing on Windows, gradlew.bat should be used instead.
+    type: string
+    default: 'gradlew'
 steps:
   - checkout
   - with_cache:
       cache_key: << parameters.cache_key >>
-      cache_checksum_file: << parameters.cache_checksum_file >>
+      deps_checksum_file: << parameters.deps_checksum_file >>
+      wrapper_checksum_file: << parameters.wrapper_checksum_file >>
       steps:
         - run:
             name: Run Tests

--- a/src/scripts/checksum_files.sh
+++ b/src/scripts/checksum_files.sh
@@ -1,1 +1,1 @@
-find . -name "${PARAM_CHECKSUM_FILES}" | sort | xargs cat | shasum | awk '{print $1}' > /tmp/gradle_cache_seed
+find . -name "${PARAM_CHECKSUM_FILES}" | sort | xargs cat | shasum | awk '{print $1}' > "${CHECKSUM_SEED_LOCATION}"


### PR DESCRIPTION
Implements #12. Split `cache_checksum_file` parameters from `with_cache` (propagated through run and test jobs), into `deps_checksum_file` and `wrapper_checksum_file` parameters.

This unlinks the gradle wrapper and dependencies from being cached again when the other changes. 