### PR TITLE
Fix: Changed default image to openjdk LTS

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -24,6 +24,7 @@ jobs:
             else
               echo Gradle successfully installed.
             fi
+      - run: java --version
 workflows:
   test-deploy:
     jobs:

--- a/sample_app/gradle/wrapper/gradle-wrapper.properties
+++ b/sample_app/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -5,7 +5,7 @@ docker:
   - image: 'cimg/openjdk:<<parameters.tag>>'
 parameters:
   tag:
-    default: "17.0"
+    default: "11.0"
     description: >
       Pick a specific cimg/openjdk image tag:
       https://hub.docker.com/r/cimg/openjdk/tags

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -5,7 +5,7 @@ docker:
   - image: 'cimg/openjdk:<<parameters.tag>>'
 parameters:
   tag:
-    default: "13.0"
+    default: "17.0"
     description: >
       Pick a specific cimg/openjdk image tag:
       https://hub.docker.com/r/cimg/openjdk/tags


### PR DESCRIPTION
This should close #23, downgrades our default executor to openjdk 11.0, an LTS, rather than openjdk 13.0, which is no longer supported by redhat. This version was picked as updating to the more recent LTS 17.0 breaks builds for users on versions of gradle older than 7.3, which was released in November of 2021. Java 11 supports users with gradle versions as old as 5.0, which was released in November 2018, as well as users using the most up to date version of gradle.