### PR TITLE
refactor: removed wrapper_checksum_file

### DIFF
--- a/src/commands/with_cache.yml
+++ b/src/commands/with_cache.yml
@@ -18,10 +18,6 @@ parameters:
     description: Files to use to generate the cache checksum for dependencies. Defaults to build.gradle. For example if using Gradle Kotlin DSL then set to build.gradle.kts instead. To use multiple files separate each with commas for example 'build.gradle.kts, settings.gradle.kts, libs.versions.toml'
     type: string
     default:  'build.gradle, build.gradle.kts, settings.gradle.kts, libs.versions.toml'
-  wrapper_checksum_file:
-    description: Files to use to generate the cache checksum for the gradle wrapper. Defaults to gradlew. For example, if testing on Windows, gradlew.bat should be used instead. To use multiple files separate each with commas for example 'build.gradle.kts, settings.gradle.kts, libs.versions.toml'
-    type: string
-    default: "gradle/wrapper/gradle-wrapper.properties"
 steps:
   - run:
       name: Generate Dependencies Checksum
@@ -33,7 +29,7 @@ steps:
       name: Generate Wrapper Checksum
       command: << include(scripts/checksum_files.sh) >>
       environment:
-        PARAM_CHECKSUM_FILES: << parameters.wrapper_checksum_file>>
+        PARAM_CHECKSUM_FILES: "gradle-wrapper.properties"
         CHECKSUM_SEED_LOCATION: "/tmp/gradle_wrapper_cache_seed"
   - restore_cache:
       key: gradle-<< parameters.cache_key>>-{{ checksum "/tmp/gradle_dep_cache_seed" }}

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -21,16 +21,11 @@ parameters:
     description: File to use to generate the cache checksum for dependencies. Defaults to build.gradle. For example if using Gradle Kotlin DSL then set to build.gradle.kts instead.
     type: string
     default: 'build.gradle'
-  wrapper_checksum_file:
-    description: File to use to generate the cache checksum for the gradle wrapper. Defaults to gradlew. For example, if testing on Windows, gradlew.bat should be used instead.
-    type: string
-    default: 'gradlew'
 steps:
   - checkout
   - with_cache:
       cache_key: << parameters.cache_key >>
       deps_checksum_file: << parameters.deps_checksum_file >>
-      wrapper_checksum_file: << parameters.wrapper_checksum_file >>
       steps:
         - run:
             working_directory: << parameters.app_src_directory >>

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -29,16 +29,11 @@ parameters:
     description: File to use to generate the cache checksum for dependencies. Defaults to build.gradle. For example if using Gradle Kotlin DSL then set to build.gradle.kts instead.
     type: string
     default: 'build.gradle, build.gradle.kts, settings.gradle.kts, libs.versions.toml'
-  wrapper_checksum_file:
-    description: File to use to generate the cache checksum for the gradle wrapper. Defaults to gradlew. For example, if testing on Windows, gradlew.bat should be used instead.
-    type: string
-    default: 'gradlew'
 steps:
   - checkout
   - with_cache:
       cache_key: << parameters.cache_key >>
       deps_checksum_file: << parameters.deps_checksum_file >>
-      wrapper_checksum_file: << parameters.wrapper_checksum_file >>
       steps:
         - run:
             name: Run Tests


### PR DESCRIPTION
Removed `wrapper_checksum_file` parameter to simplify the orb as it should always be `gradle-wrapper.properties`