### PR TITLE
refactor: removed maven references

### DIFF
--- a/src/commands/with_cache.yml
+++ b/src/commands/with_cache.yml
@@ -11,7 +11,7 @@ parameters:
   steps:
     type: steps
   cache_key:
-    description: Add a custom suffix to your cache key in the event you need to work with multiple maven caches.
+    description: Add a custom suffix to your cache key in the event you need to work with multiple gradle caches.
     type: string
     default: "v1"
   deps_checksum_file:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -7,14 +7,14 @@ parameters:
     type: executor
     default: default
   app_src_directory:
-    description: Useful when the source of your maven project is not in the root directory of your git repo. Supply the name of the directory or relative path of the directory containing your source code.
+    description: Useful when the source of your gradle project is not in the root directory of your git repo. Supply the name of the directory or relative path of the directory containing your source code.
     type: string
     default: ''
   command:
     type: string
     default: build
   cache_key:
-    description: Add a custom suffix to your cache key in the event you need to work with multiple maven caches.
+    description: Add a custom suffix to your cache key in the event you need to work with multiple gradle caches.
     type: string
     default: 'v1'
   deps_checksum_file:

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -18,11 +18,11 @@ parameters:
     type: string
     default: build/reports/
   app_src_directory:
-    description: Useful when the source of your maven project is not in the root directory of your git repo. Supply the name of the directory or relative path of the directory containing your source code.
+    description: Useful when the source of your gradle project is not in the root directory of your git repo. Supply the name of the directory or relative path of the directory containing your source code.
     type: string
     default: ''
   cache_key:
-    description: Add a custom suffix to your cache key in the event you need to work with multiple maven caches.
+    description: Add a custom suffix to your cache key in the event you need to work with multiple gradle caches.
     type: string
     default: 'v1'
   deps_checksum_file:


### PR DESCRIPTION
This fixes issues where parameters were described with references to maven instead of gradle. This should close #26 