### PR TITLE
Ensure the collection script to find test results always runs

### DIFF
--- a/src/commands/collect_test_results.yml
+++ b/src/commands/collect_test_results.yml
@@ -28,6 +28,7 @@ steps:
             command: |
               mkdir -p /tmp/test_results/junit
               find . -name '*TEST-*.xml' -exec cp -v {} /tmp/test_results/junit \;
+            when: always
         - store_test_results:
             path: /tmp/test_results
         - store_artifacts:


### PR DESCRIPTION
The issue when not specifying `when: always` for that command is that although store_test_results and store_artifacts implicitly always runs even if the build is failing, homegrown commands like the one provided here don't. Thus the need to add `when: always` to force it to run regardless of build status.

This should fix #35.